### PR TITLE
Feature/code editor widget

### DIFF
--- a/DevGarden.pro
+++ b/DevGarden.pro
@@ -27,7 +27,9 @@ SOURCES += \
     src/ui/dgwindow.cpp \
     src/dgcontroller.cpp \
     src/ui/dgcentralwidget.cpp \
-    src/configloader.cpp
+    src/configloader.cpp \
+    src/ui/editor/codeeditorwidget.cpp \
+    src/ui/editor/syntaxhighlighter.cpp
 
 HEADERS  += \
     src/ui/dgwindow.h \
@@ -35,11 +37,11 @@ HEADERS  += \
     src/util/stringtree.h \
     src/ui/dgcentralwidget.hpp \
     src/configloader.h \
-    src/envmacros.h
+    src/envmacros.h \
+    src/ui/editor/codeeditorwidget.h \
+    src/ui/editor/linenumberarea.h \
+    src/ui/editor/syntaxhighlighter.h
 
 FORMS    +=
 
 TRANSLATIONS = DevGarden_fr.ts
-
-DISTFILES += \
-    DGCentralDesignThought.txt

--- a/src/ui/dgcentralwidget.cpp
+++ b/src/ui/dgcentralwidget.cpp
@@ -1,4 +1,5 @@
 #include "dgcentralwidget.hpp"
+#include "editor/codeeditorwidget.h"
 
 #include <QFileSystemModel>
 #include <QCoreApplication>
@@ -40,7 +41,7 @@ void DGCentralWidget::createWidgets()
 	auxPane->setPlainText("Auxiliary\nPane\nPlaceholder");
 
 	// Text Editor
-	textEditor = new QPlainTextEdit;
+	textEditor = new CodeEditorWidget;
 	textEditor->setPlainText("#include <iostream>\n\n"
 							 "int main()\n"
 							 "{\n"

--- a/src/ui/dgcentralwidget.hpp
+++ b/src/ui/dgcentralwidget.hpp
@@ -39,4 +39,3 @@ class DGCentralWidget : public QWidget
 };
 
 #endif // DGCENTRALWIDGET_HPP
-

--- a/src/ui/dgcentralwidget.hpp
+++ b/src/ui/dgcentralwidget.hpp
@@ -9,6 +9,7 @@ class QComboBox;
 class QPlainTextEdit;
 class QLineEdit;
 class QPushButton;
+class CodeEditorWidget;
 
 class DGCentralWidget : public QWidget
 {
@@ -31,7 +32,7 @@ class DGCentralWidget : public QWidget
 		// Widgets
 		QComboBox* auxComboBox;
 		QPlainTextEdit* auxPane; // Just a placeholder till custom widget is created.
-		QPlainTextEdit* textEditor;
+		CodeEditorWidget* textEditor;
 		QLineEdit* bottomBar; // Placeholder
 		QPlainTextEdit* splitViewPane; // Placeholder
 		QPushButton* bottomButton;

--- a/src/ui/editor/codeeditorwidget.cpp
+++ b/src/ui/editor/codeeditorwidget.cpp
@@ -4,18 +4,12 @@
 #include <QPainter>
 #include <QTextBlock>
 
-CodeEditorWidget::CodeEditorWidget(QWidget* parent)
+CodeEditorWidget::CodeEditorWidget(QWidget* parent) :
+	QPlainTextEdit(parent)
 {
 	lineNumberArea = new LineNumberArea(this);
 
-	// Connections
-	connect(this, SIGNAL(blockCountChanged(int)), this, SLOT(updateLineNumberAreaWidth(int)));
-	connect(this, SIGNAL(updateRequest(QRect,int)), this, SLOT(updateLineNumberArea(QRect, int)));
-	connect(this, SIGNAL(cursorPositionChanged()), this, SLOT(highlightCurrentLine()));
-
-	updateLineNumberAreaWidth(0);
-
-	// Modify background/text of the editor
+	// Modify editor color and font settings
 	QColor backgroundColor = QColor(39,40,34);
 	QPalette colors = palette();
 	colors.setColor(QPalette::Active, QPalette::Base, backgroundColor);
@@ -23,20 +17,28 @@ CodeEditorWidget::CodeEditorWidget(QWidget* parent)
 	colors.setColor(QPalette::Text, Qt::white);
 	setPalette(colors);
 
-	setFont(QFont("Consolas", 10));
+	QFont font = QFont("Consolas", 10);
+	font.setBold(true);
+	setFont(font);
 
-	// Syntax highlighting
+	// Syntax highlighting. If you wish to turn off syntax highlighting
+	// at the moment only way to do so is to not initialize the member.
+	// Will work on getting up more control over this in future updates.
 	syntaxHighlighter = new SyntaxHighlighter(document());
+
+	createConnections();
+	updateLineNumberAreaWidth();
 }
 
+// Paints line number area off to the left
 void CodeEditorWidget::lineNumberPaintEvent(QPaintEvent *event)
 {
 	QPainter painter(lineNumberArea);
-	painter.fillRect(event->rect(), QColor(59,58,50).lighter(160));
+	painter.fillRect(event->rect(), QColor(59,58,50).lighter(160)); // TODO: Maybe get rid of magic number for color?
 
 	QTextBlock block = firstVisibleBlock();
 	int blockNumber = block.blockNumber();
-	int top = (int) blockBoundingGeometry(block).translated(contentOffset()).top();
+	int top = static_cast<int>(blockBoundingGeometry(block).translated(contentOffset()).top());
 	int bottom = top + static_cast<int>(blockBoundingRect(block).height());
 
 	while (block.isValid() && top <= event->rect().bottom())
@@ -56,6 +58,7 @@ void CodeEditorWidget::lineNumberPaintEvent(QPaintEvent *event)
 	}
 }
 
+// Overload needed to handle resizing the line number area which is manually painted on.
 void CodeEditorWidget::resizeEvent(QResizeEvent *e)
 {
 	QPlainTextEdit::resizeEvent(e);
@@ -64,6 +67,15 @@ void CodeEditorWidget::resizeEvent(QResizeEvent *e)
 	lineNumberArea->setGeometry(QRect(contRect.left(), contRect.top(), lineNumberAreaWidth(), contRect.height()));
 }
 
+// Creates signal/slot connections
+void CodeEditorWidget::createConnections()
+{
+	connect(this, SIGNAL(blockCountChanged(int)), this, SLOT(updateLineNumberAreaWidth(int)));
+	connect(this, SIGNAL(updateRequest(QRect,int)), this, SLOT(updateLineNumberArea(QRect, int)));
+	connect(this, SIGNAL(cursorPositionChanged()), this, SLOT(highlightCurrentLine()));
+}
+
+// Helper function for line number area
 int CodeEditorWidget::lineNumberAreaWidth()
 {
 	int digits = 1;
@@ -74,16 +86,17 @@ int CodeEditorWidget::lineNumberAreaWidth()
 		++digits;
 	}
 
-	int space = 3 + fontMetrics().width(QLatin1Char('9')) * digits;
+	int space = 5 + fontMetrics().width(QLatin1Char('9')) * digits;
 
 	return space;
 }
 
-void CodeEditorWidget::updateLineNumberAreaWidth(int newBlockCount)
+void CodeEditorWidget::updateLineNumberAreaWidth()
 {
 	setViewportMargins(lineNumberAreaWidth(), 0, 0, 0);
 }
 
+// Called to highlight the current line
 void CodeEditorWidget::highlightCurrentLine()
 {
 	QList<QTextEdit::ExtraSelection> extraSelections;
@@ -112,6 +125,6 @@ void CodeEditorWidget::updateLineNumberArea(const QRect& rect, int dy)
 		lineNumberArea->update(0, rect.y(), lineNumberArea->width(), rect.height());
 
 	if (rect.contains(viewport()->rect()))
-		updateLineNumberAreaWidth(0);
+		updateLineNumberAreaWidth();
 }
 

--- a/src/ui/editor/codeeditorwidget.cpp
+++ b/src/ui/editor/codeeditorwidget.cpp
@@ -1,0 +1,117 @@
+#include "codeeditorwidget.h"
+#include "syntaxhighlighter.h"
+#include "linenumberarea.h"
+#include <QPainter>
+#include <QTextBlock>
+
+CodeEditorWidget::CodeEditorWidget(QWidget* parent)
+{
+	lineNumberArea = new LineNumberArea(this);
+
+	// Connections
+	connect(this, SIGNAL(blockCountChanged(int)), this, SLOT(updateLineNumberAreaWidth(int)));
+	connect(this, SIGNAL(updateRequest(QRect,int)), this, SLOT(updateLineNumberArea(QRect, int)));
+	connect(this, SIGNAL(cursorPositionChanged()), this, SLOT(highlightCurrentLine()));
+
+	updateLineNumberAreaWidth(0);
+
+	// Modify background/text of the editor
+	QColor backgroundColor = QColor(39,40,34);
+	QPalette colors = palette();
+	colors.setColor(QPalette::Active, QPalette::Base, backgroundColor);
+	colors.setColor(QPalette::Inactive, QPalette::Base, backgroundColor);
+	colors.setColor(QPalette::Text, Qt::white);
+	setPalette(colors);
+
+	setFont(QFont("Consolas", 10));
+
+	// Syntax highlighting
+	syntaxHighlighter = new SyntaxHighlighter(document());
+}
+
+void CodeEditorWidget::lineNumberPaintEvent(QPaintEvent *event)
+{
+	QPainter painter(lineNumberArea);
+	painter.fillRect(event->rect(), QColor(59,58,50).lighter(160));
+
+	QTextBlock block = firstVisibleBlock();
+	int blockNumber = block.blockNumber();
+	int top = (int) blockBoundingGeometry(block).translated(contentOffset()).top();
+	int bottom = top + static_cast<int>(blockBoundingRect(block).height());
+
+	while (block.isValid() && top <= event->rect().bottom())
+	{
+		if (block.isVisible() && bottom >= event->rect().top())
+		{
+			QString number = QString::number(blockNumber + 1);
+			painter.setPen(QColor(188,188,188));
+			painter.setFont(QFont("Consolas", 10));
+			painter.drawText(0, top, lineNumberArea->width(), fontMetrics().height(), Qt::AlignRight, number);
+		}
+
+		block = block.next();
+		top = bottom;
+		bottom = top + static_cast<int>(blockBoundingRect(block).height());
+		++blockNumber;
+	}
+}
+
+void CodeEditorWidget::resizeEvent(QResizeEvent *e)
+{
+	QPlainTextEdit::resizeEvent(e);
+
+	QRect contRect = contentsRect();
+	lineNumberArea->setGeometry(QRect(contRect.left(), contRect.top(), lineNumberAreaWidth(), contRect.height()));
+}
+
+int CodeEditorWidget::lineNumberAreaWidth()
+{
+	int digits = 1;
+	int max = qMax(1, blockCount());
+	while (max >= 10)
+	{
+		max /= 10;
+		++digits;
+	}
+
+	int space = 3 + fontMetrics().width(QLatin1Char('9')) * digits;
+
+	return space;
+}
+
+void CodeEditorWidget::updateLineNumberAreaWidth(int newBlockCount)
+{
+	setViewportMargins(lineNumberAreaWidth(), 0, 0, 0);
+}
+
+void CodeEditorWidget::highlightCurrentLine()
+{
+	QList<QTextEdit::ExtraSelection> extraSelections;
+
+	if (!isReadOnly())
+	{
+		QTextEdit::ExtraSelection selection;
+
+		QColor lineColor = QColor(73,72,62);
+
+		selection.format.setBackground(lineColor);
+		selection.format.setProperty(QTextFormat::FullWidthSelection, true);
+		selection.cursor = textCursor();
+		selection.cursor.clearSelection();
+		extraSelections.append(selection);
+	}
+
+	setExtraSelections(extraSelections);
+}
+
+void CodeEditorWidget::updateLineNumberArea(const QRect& rect, int dy)
+{
+	if (dy)
+		lineNumberArea->scroll(0, dy);
+	else
+		lineNumberArea->update(0, rect.y(), lineNumberArea->width(), rect.height());
+
+	if (rect.contains(viewport()->rect()))
+		updateLineNumberAreaWidth(0);
+}
+

--- a/src/ui/editor/codeeditorwidget.h
+++ b/src/ui/editor/codeeditorwidget.h
@@ -1,0 +1,32 @@
+#ifndef CODEEDITORWIDGET_H
+#define CODEEDITORWIDGET_H
+
+#include <QObject>
+#include <QPlainTextEdit>
+
+class SyntaxHighlighter;
+
+class CodeEditorWidget : public QPlainTextEdit
+{
+	Q_OBJECT
+
+	public:
+		CodeEditorWidget(QWidget* parent = 0);
+
+		void lineNumberPaintEvent(QPaintEvent* event);
+		int lineNumberAreaWidth();
+
+	protected:
+		void resizeEvent(QResizeEvent *e) Q_DECL_OVERRIDE;
+
+	private slots:
+		void updateLineNumberAreaWidth(int newBlockCount);
+		void highlightCurrentLine();
+		void updateLineNumberArea(const QRect& rect, int dy);
+
+	private:
+		QWidget* lineNumberArea;
+		SyntaxHighlighter* syntaxHighlighter;
+};
+
+#endif // CODEEDITORWIDGET_H

--- a/src/ui/editor/codeeditorwidget.h
+++ b/src/ui/editor/codeeditorwidget.h
@@ -19,8 +19,11 @@ class CodeEditorWidget : public QPlainTextEdit
 	protected:
 		void resizeEvent(QResizeEvent *e) Q_DECL_OVERRIDE;
 
+	private:
+		void createConnections();
+
 	private slots:
-		void updateLineNumberAreaWidth(int newBlockCount);
+		void updateLineNumberAreaWidth();
 		void highlightCurrentLine();
 		void updateLineNumberArea(const QRect& rect, int dy);
 

--- a/src/ui/editor/linenumberarea.h
+++ b/src/ui/editor/linenumberarea.h
@@ -1,0 +1,31 @@
+#ifndef LINE_NUMBER_AREA
+#define LINE_NUMBER_AREA
+
+#include <QWidget>
+#include <QSize>
+#include "codeeditorwidget.h"
+
+class LineNumberArea : public QWidget
+{
+	Q_OBJECT
+
+	public:
+		LineNumberArea(CodeEditorWidget* editor) : QWidget(editor), codeEditor(editor) {}
+
+		QSize sizeHint() const Q_DECL_OVERRIDE
+		{
+			return QSize(codeEditor->lineNumberAreaWidth(), 0);
+		}
+
+	protected:
+		void paintEvent(QPaintEvent* event) Q_DECL_OVERRIDE
+		{
+			codeEditor->lineNumberPaintEvent(event);
+		}
+
+	private:
+		CodeEditorWidget* codeEditor;
+};
+
+#endif // LINE_NUMBER_AREA
+

--- a/src/ui/editor/syntaxhighlighter.cpp
+++ b/src/ui/editor/syntaxhighlighter.cpp
@@ -1,0 +1,117 @@
+#include "syntaxhighlighter.h"
+
+SyntaxHighlighter::SyntaxHighlighter(QTextDocument* parent)
+	: QSyntaxHighlighter(parent)
+{
+	HighlightingRule rule;
+
+	keywordFormat.setForeground(QColor(102,217,239));
+	QStringList keywordPatterns;
+	keywordPatterns << "\\bchar\\b" << "\\bclass\\b" << "\\bconst\\b"
+					<< "\\bdouble\\b" << "\\benum\\b"
+					<< "\\bfriend\\b" << "\\binline\\b" << "\\bint\\b"
+					<< "\\blong\\b" << "\\bnamespace\\b" << "\\boperator\\b"
+					<< "\\bvolatile\\b"
+					<< "\\bshort\\b" << "\\bsignals\\b" << "\\bsigned\\b"
+					<< "\\bslots\\b" << "\\bstatic\\b" << "\\bstruct\\b"
+					<< "\\btemplate\\b" << "\\btypedef\\b" << "\\btypename\\b"
+					<< "\\bunion\\b" << "\\bunsigned\\b"
+					<< "\\bvoid\\b";
+
+	foreach (const QString& pattern, keywordPatterns)
+	{
+		rule.pattern = QRegExp(pattern);
+		rule.format = keywordFormat;
+		highlightingRules.append(rule);
+	}
+
+	includeHeaderFormat.setForeground(QColor(220,213,131));
+	rule.pattern = QRegExp("include ((<[^>]+>)|(\"[^\"]+\"))");
+	rule.format = includeHeaderFormat;
+	highlightingRules.append(rule);
+
+	extraKeywordFormat.setForeground(QColor(185,38,76));
+	QStringList extraKeywordPatterns;
+	extraKeywordPatterns << "\\bprivate\\b" << "\\bpublic\\b" << "\\bprotected\\b"
+						 << "\\bifndef\\b" << "\\bendif\\b" << "\\binclude\\b"
+						 << "\\bvirtual\\b" << "\\binclude\\b" << "\\bdefine\\b"
+						 << "\\bexplicit\\b";
+
+	foreach (const QString& pattern, extraKeywordPatterns)
+	{
+		rule.pattern = QRegExp(pattern);
+		rule.format = extraKeywordFormat;
+		highlightingRules.append(rule);
+	}
+
+	integerFormat.setForeground(QColor(192,151,210));
+	rule.pattern = QRegExp("[0-9]+");
+	rule.format = integerFormat;
+	highlightingRules.append(rule);
+
+	classFormat.setForeground(Qt::white);
+	rule.pattern = QRegExp("\\bQ[A-Za-z]+\\b");
+	rule.format = classFormat;
+	highlightingRules.append(rule);
+
+	quotationFormat.setForeground(QColor(230,219,103));
+	rule.pattern = QRegExp("\".*\"");
+	rule.format = quotationFormat;
+	highlightingRules.append(rule);
+
+	functionFormat.setFontItalic(true);
+	functionFormat.setForeground(QColor(166,226,44));
+	rule.pattern = QRegExp("\\b[A-Za-z0-9_]+(?=\\()");
+	rule.format = functionFormat;
+	highlightingRules.append(rule);
+
+	singleLineCommentFormat.setForeground(QColor(104,102,83));
+	rule.pattern = QRegExp("//[^\n]*");
+	rule.format = singleLineCommentFormat;
+	highlightingRules.append(rule);
+
+	multiLineCommentFormat.setForeground(QColor(104,102,83).lighter(240));
+
+	commentStartExp = QRegExp("/\\*");
+	commentEndExp = QRegExp("\\*/");
+}
+
+void SyntaxHighlighter::highlightBlock(const QString& text)
+{
+	foreach (const HighlightingRule &rule, highlightingRules)
+	{
+		QRegExp expression(rule.pattern);
+		int index = expression.indexIn(text);
+		while (index >= 0)
+		{
+			int length = expression.matchedLength();
+			setFormat(index, length, rule.format);
+			index = expression.indexIn(text, index + length);
+		}
+	}
+
+	setCurrentBlockState(0);
+
+	int startIndex = 0;
+	if (previousBlockState() != 1)
+		startIndex = commentStartExp.indexIn(text);
+
+	while (startIndex >= 0)
+	{
+		int endIndex = commentEndExp.indexIn(text, startIndex);
+		int commentLength;
+		if (endIndex == -1)
+		{
+			setCurrentBlockState(1);
+			commentLength = text.length() - startIndex;
+		}
+		else
+		{
+			commentLength = endIndex - startIndex + commentEndExp.matchedLength();
+		}
+
+		setFormat(startIndex, commentLength, multiLineCommentFormat);
+		startIndex = commentStartExp.indexIn(text, startIndex + commentLength);
+	}
+}
+

--- a/src/ui/editor/syntaxhighlighter.cpp
+++ b/src/ui/editor/syntaxhighlighter.cpp
@@ -5,7 +5,17 @@ SyntaxHighlighter::SyntaxHighlighter(QTextDocument* parent)
 {
 	HighlightingRule rule;
 
-	keywordFormat.setForeground(QColor(102,217,239));
+	// Highlight colors
+	keywordColor = QColor(102,217,239);
+	headerColor = QColor(220,213,131);
+	extraKeywordColor = QColor(185,38,76);
+	integerColor = QColor(192,151,210);
+	classColor = Qt::white;
+	quotationColor = QColor(230,219,103);
+	functionColor = QColor(166,226,44);
+	commentColor = QColor(104,102,83).lighter(240);
+
+	keywordFormat.setForeground(keywordColor);
 	QStringList keywordPatterns;
 	keywordPatterns << "\\bchar\\b" << "\\bclass\\b" << "\\bconst\\b"
 					<< "\\bdouble\\b" << "\\benum\\b"
@@ -25,12 +35,12 @@ SyntaxHighlighter::SyntaxHighlighter(QTextDocument* parent)
 		highlightingRules.append(rule);
 	}
 
-	includeHeaderFormat.setForeground(QColor(220,213,131));
+	includeHeaderFormat.setForeground(headerColor);
 	rule.pattern = QRegExp("include ((<[^>]+>)|(\"[^\"]+\"))");
 	rule.format = includeHeaderFormat;
 	highlightingRules.append(rule);
 
-	extraKeywordFormat.setForeground(QColor(185,38,76));
+	extraKeywordFormat.setForeground(extraKeywordColor);
 	QStringList extraKeywordPatterns;
 	extraKeywordPatterns << "\\bprivate\\b" << "\\bpublic\\b" << "\\bprotected\\b"
 						 << "\\bifndef\\b" << "\\bendif\\b" << "\\binclude\\b"
@@ -44,33 +54,33 @@ SyntaxHighlighter::SyntaxHighlighter(QTextDocument* parent)
 		highlightingRules.append(rule);
 	}
 
-	integerFormat.setForeground(QColor(192,151,210));
+	integerFormat.setForeground(integerColor);
 	rule.pattern = QRegExp("[0-9]+");
 	rule.format = integerFormat;
 	highlightingRules.append(rule);
 
-	classFormat.setForeground(Qt::white);
+	classFormat.setForeground(classColor);
 	rule.pattern = QRegExp("\\bQ[A-Za-z]+\\b");
 	rule.format = classFormat;
 	highlightingRules.append(rule);
 
-	quotationFormat.setForeground(QColor(230,219,103));
+	quotationFormat.setForeground(quotationColor);
 	rule.pattern = QRegExp("\".*\"");
 	rule.format = quotationFormat;
 	highlightingRules.append(rule);
 
 	functionFormat.setFontItalic(true);
-	functionFormat.setForeground(QColor(166,226,44));
+	functionFormat.setForeground(functionColor);
 	rule.pattern = QRegExp("\\b[A-Za-z0-9_]+(?=\\()");
 	rule.format = functionFormat;
 	highlightingRules.append(rule);
 
-	singleLineCommentFormat.setForeground(QColor(104,102,83));
+	singleLineCommentFormat.setForeground(commentColor);
 	rule.pattern = QRegExp("//[^\n]*");
 	rule.format = singleLineCommentFormat;
 	highlightingRules.append(rule);
 
-	multiLineCommentFormat.setForeground(QColor(104,102,83).lighter(240));
+	multiLineCommentFormat.setForeground(commentColor);
 
 	commentStartExp = QRegExp("/\\*");
 	commentEndExp = QRegExp("\\*/");

--- a/src/ui/editor/syntaxhighlighter.h
+++ b/src/ui/editor/syntaxhighlighter.h
@@ -1,0 +1,39 @@
+#ifndef SYNTAX_HIGHLIGHTER_H
+#define SYNTAX_HIGHLIGHTER_H
+
+#include <QSyntaxHighlighter>
+
+class SyntaxHighlighter : public QSyntaxHighlighter
+{
+	Q_OBJECT
+
+	public:
+		SyntaxHighlighter(QTextDocument* parent = 0);
+
+	protected:
+		void highlightBlock(const QString& text) Q_DECL_OVERRIDE;
+
+	private:
+		struct HighlightingRule
+		{
+			QRegExp pattern;
+			QTextCharFormat format;
+		};
+
+		QVector<HighlightingRule> highlightingRules;
+
+		QRegExp commentStartExp;
+		QRegExp commentEndExp;
+
+		QTextCharFormat keywordFormat;
+		QTextCharFormat integerFormat;
+		QTextCharFormat includeHeaderFormat;
+		QTextCharFormat extraKeywordFormat;
+		QTextCharFormat classFormat;
+		QTextCharFormat singleLineCommentFormat;
+		QTextCharFormat multiLineCommentFormat;
+		QTextCharFormat quotationFormat;
+		QTextCharFormat functionFormat;
+};
+
+#endif // SYNTAX_HIGHLIGHTER_H

--- a/src/ui/editor/syntaxhighlighter.h
+++ b/src/ui/editor/syntaxhighlighter.h
@@ -26,14 +26,29 @@ class SyntaxHighlighter : public QSyntaxHighlighter
 		QRegExp commentEndExp;
 
 		QTextCharFormat keywordFormat;
+		QColor keywordColor;
+
 		QTextCharFormat integerFormat;
+		QColor integerColor;
+
 		QTextCharFormat includeHeaderFormat;
+		QColor headerColor;
+
 		QTextCharFormat extraKeywordFormat;
+		QColor extraKeywordColor;
+
 		QTextCharFormat classFormat;
+		QColor classColor;
+
 		QTextCharFormat singleLineCommentFormat;
 		QTextCharFormat multiLineCommentFormat;
+		QColor commentColor;
+
 		QTextCharFormat quotationFormat;
+		QColor quotationColor;
+
 		QTextCharFormat functionFormat;
+		QColor functionColor;
 };
 
 #endif // SYNTAX_HIGHLIGHTER_H


### PR DESCRIPTION
Implements the base functionality for syntax highlighting (Monokai look alike) for C++ and some extra features like line numbers and current line highlighting.

* Line numbers though custom painting on the widget
* Basic syntax highlighting only for C++ using Regex searching
* Current line highlighting

Some room for improvement would be to make editing of the color scheme available, can either do this through making the color members visible to other classes, or ideally later on refactoring to use stylesheets or something similar to determine the style of the syntax highlighting.

Will be working on some more cleanup of these classes especially CodeEditorWidget which will act as the host of all the visual features of the editor widget.